### PR TITLE
Fix executable path and working directory in Docker Container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,6 @@ VOLUME /opt/factorio/saves /opt/factorio/mods /opt/factorio/config /security
 RUN apk add --no-cache curl tar unzip nginx openssl
 
 WORKDIR /opt/
-COPY "init.sh" "/opt/init.sh"
-COPY "nginx.conf" "/etc/nginx/nginx.conf"
 
 RUN curl -s -L -S -k https://www.factorio.com/get-download/$FACTORIO_VERSION/headless/linux64 -o /tmp/factorio_$FACTORIO_VERSION.tar.gz && \
     tar zxf /tmp/factorio_$FACTORIO_VERSION.tar.gz && \
@@ -23,6 +21,9 @@ RUN curl -s -L -S -k https://www.factorio.com/get-download/$FACTORIO_VERSION/hea
     rm /tmp/factorio-server-manager-linux-x64_$MANAGER_VERSION.zip && \
     mkdir -p /run/nginx && \
     chown nginx:root /var/lib/nginx
+
+COPY "init.sh" "/opt/init.sh"
+COPY "nginx.conf" "/etc/nginx/nginx.conf"
 
 EXPOSE 80/tcp 443/tcp 34190-34200/udp
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,4 +14,5 @@ if [ ! -f /security/server.key ]; then
 fi
 
 nohup nginx &
-/opt/factorio-server/factorio-server-manager -dir '/opt/factorio' -conf '/opt/factorio-server/conf.json'
+cd /opt/factorio-server-manager
+./factorio-server-manager -dir '/opt/factorio'


### PR DESCRIPTION
The path of the executable changed from `/opt/factorio-server/factorio-server-manager` to `/opt/factorio-server-manager/factorio-server-manager`. 

Additionally the backend was not able to find the web files without changing to the directory first.

This PR fixes those issues.