### PR TITLE
change --rcon-pass argument to --rcon-password

### DIFF
--- a/src/factorio_server.go
+++ b/src/factorio_server.go
@@ -108,7 +108,7 @@ func (f *FactorioServer) Run() error {
 		"--port", strconv.Itoa(f.Port),
 		"--server-settings", filepath.Join(config.FactorioConfigDir, "server-settings.json"),
 		"--rcon-port", strconv.Itoa(config.FactorioRconPort),
-		"--rcon-pass", config.FactorioRconPass,
+		"--rcon-password", config.FactorioRconPass,
 	}
 
 	if f.Savefile == "Load Latest" {


### PR DESCRIPTION
see https://wiki.factorio.com/Console#Command_Line_Parameters for details,
forum posts mentioned that this changed happened back in ~1.3.

The wiki itself had these arguments added on jan 20th, 2017, so this is not a new thing.