### PR TITLE
Update: use latest manager version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM frolvlad/alpine-glibc
 MAINTAINER Mitch Roote <mitch@r00t.ca>
 
 ENV FACTORIO_VERSION=latest \
-    MANAGER_VERSION=0.6.0 \
+    MANAGER_VERSION=0.6.1 \
     ADMIN_PASSWORD=factorio
 
 VOLUME /opt/factorio/saves /opt/factorio/mods /opt/factorio/config /security


### PR DESCRIPTION
This keeps people from hitting the `rcon-pass` flag renaming bug in the future.