### PR TITLE
fixed crash, when mods have no basemodversion defined

### DIFF
--- a/src/mod_modInfo.go
+++ b/src/mod_modInfo.go
@@ -77,6 +77,13 @@ func (modInfoList *ModInfoList) listInstalledMods() error {
 			var baseDependency string
 			for _, dependency := range modInfo.Dependencies {
 				if strings.HasPrefix(dependency, "base") {
+					splittedDep := strings.Split(dependency, "=")
+
+					if len(splittedDep) == 1 {
+						log.Printf("basemod without version specified!")
+						break
+					}
+
 					baseDependency = strings.Split(dependency, "=")[1]
 					break
 				}


### PR DESCRIPTION
Fixed bug, that caused the manager to crash, when no basemodversion is defined.
#118 #113 