### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/src/handlers.go
+++ b/src/handlers.go
@@ -199,7 +199,7 @@ func CreateSaveHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Returns last lines of the factorio-current.log file
+// LogTail returns last lines of the factorio-current.log file
 func LogTail(w http.ResponseWriter, r *http.Request) {
 	var err error
 	resp := JSONResponse{
@@ -224,7 +224,7 @@ func LogTail(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Return JSON response of config.ini file
+// LoadConfig returns JSON response of config.ini file
 func LoadConfig(w http.ResponseWriter, r *http.Request) {
 	var err error
 	resp := JSONResponse{
@@ -694,7 +694,7 @@ func RemoveUser(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Return JSON response of server-settings.json file
+// GetServerSettings returns JSON response of server-settings.json file
 func GetServerSettings(w http.ResponseWriter, r *http.Request) {
 	resp := JSONResponse{
 		Success: false,

--- a/src/mods_handler.go
+++ b/src/mods_handler.go
@@ -62,7 +62,7 @@ func listInstalledModsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Returns JSON response with success or error-message
+// LoginFactorioModPortal returns JSON response with success or error-message
 func LoginFactorioModPortal(w http.ResponseWriter, r *http.Request) {
 	var err error
 	resp := JSONResponse{
@@ -147,7 +147,7 @@ func LogoutFactorioModPortalHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//Returns JSON response with the found mods
+//ModPortalSearchHandler returns JSON response with the found mods
 func ModPortalSearchHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 	resp := JSONResponse{
@@ -180,7 +180,7 @@ func ModPortalSearchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//Returns JSON response with the mod details
+//ModPortalDetailsHandler returns JSON response with the mod details
 func ModPortalDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 	resp := JSONResponse{
@@ -567,7 +567,7 @@ func DownloadModsHandler(w http.ResponseWriter, r *http.Request) {
 	writerHeader.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", "all_installed_mods.zip"))
 }
 
-//Returns JSON response with the found mods
+//LoadModsFromSaveHandler returns JSON response with the found mods
 func LoadModsFromSaveHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 	resp := JSONResponse{


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?