### PR TITLE
Fix for the glibc issue on RHEL/Centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,19 @@ Usage of ./factorio-server-manager:
     	Maximum filesize for uploaded files (default 20MB). (default 20971520)
   -port string
     	Specify a port for the server. (default "8080")
-
+  -glibc-custom string 
+        Specify if custom glibc is used (default false) [true/false]
+  -glibc-loc string
+        Path to the glibc ld.so file (default "/opt/glibc-2.18/lib/ld-2.18.so")
+  -glibc-lib-loc
+        Path to the glibc lib folder (default "/opt/glibc-2.18/lib")
 Example:
 
 ./factorio-server-manager --dir /home/user/.factorio --host 10.0.0.1
+
+Custom glibc example:
+
+./factorio-server-manager --dir /home/user/.factorio --host 10.0.0.1 --glibc-custom true --glibc-loc /opt/glibc-2.18/lib/ld-2.18.so --glibc-lib-loc /opt/glibc-2.18/lib
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Usage of ./factorio-server-manager:
         Path to the glibc ld.so file (default "/opt/glibc-2.18/lib/ld-2.18.so")
   -glibc-lib-loc
         Path to the glibc lib folder (default "/opt/glibc-2.18/lib")
+  -autostart
+        Autostarts Factorio Server when FSM is starting. Default false [true/false]
+        (If no IP and/or port provided at startup, it will bind the factorio server to all interfaces 
+        and set the server port to the default 34197, always loads latest save)  
+        
 Example:
 
 ./factorio-server-manager --dir /home/user/.factorio --host 10.0.0.1

--- a/src/factorio_server.go
+++ b/src/factorio_server.go
@@ -42,26 +42,6 @@ func randomPort() int {
 	// Returns random port to use for rcon connection
 	return rand.Intn(45000-40000) + 40000
 }
-func autostart() {
-
-	var err error
-	if FactorioServ.BindIP == "" {
-		FactorioServ.BindIP = "0.0.0.0"
-
-	}
-	if FactorioServ.Port == 0 {
-		FactorioServ.Port = 34197
-	}
-	FactorioServ.Savefile = "Load Latest"
-
-	err = FactorioServ.Run()
-
-	if err != nil {
-		log.Printf("Error starting Factorio server: %+v", err)
-		return
-	}
-
-}
 
 func initFactorio() (f *FactorioServer, err error) {
 	f = new(FactorioServer)
@@ -153,10 +133,6 @@ func initFactorio() (f *FactorioServer, err error) {
 
 	f.BaseModVersion = modInfo.Version
 
-	if config.autostart == "true" {
-		go autostart()
-	}
-
 	return
 }
 
@@ -191,8 +167,6 @@ func (f *FactorioServer) Run() error {
 	} else {
 		args = append(args, "--start-server", filepath.Join(config.FactorioSavesDir, f.Savefile))
 	}
-
-	log.Println("Starting server with command: ", config.FactorioBinary, args)
 
 	if config.glibcCustom == "true" {
 		log.Println("Starting server with command: ", config.glibcLocation, args)

--- a/src/factorio_server.go
+++ b/src/factorio_server.go
@@ -96,8 +96,14 @@ func initFactorio() (f *FactorioServer, err error) {
 
 	log.Printf("Loaded Factorio settings from %s\n", settingsPath)
 
+	out := []byte{}
 	//Load factorio version
-	out, err := exec.Command(config.glibcLocation, "--library-path", config.glibcLibLoc, config.FactorioBinary, "--version").Output()
+	if config.glibcCustom == "true" {
+		out, err = exec.Command(config.glibcLocation, "--library-path", config.glibcLibLoc, config.FactorioBinary, "--version").Output()
+	} else {
+		out, err = exec.Command(config.FactorioBinary, "--version").Output()
+	}
+
 	if err != nil {
 		log.Printf("error on loading factorio version: %s", err)
 		return
@@ -178,8 +184,6 @@ func (f *FactorioServer) Run() error {
 		log.Println("Starting server with command: ", config.FactorioBinary, args)
 		f.Cmd = exec.Command(config.FactorioBinary, args...)
 	}
-
-	//f.Cmd = exec.Command(config.glibcLocation, "--library-path", config.glibcLibLoc, config.FactorioBinary, args...)
 
 	f.StdOut, err = f.Cmd.StdoutPipe()
 	if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -34,6 +34,9 @@ type Config struct {
 	SettingsFile            string `json:"settings_file"`
 	LogFile                 string `json:"log_file"`
 	ConfFile                string
+	glibcCustom             string
+	glibcLocation           string
+	glibcLibLoc             string
 }
 
 var (
@@ -72,9 +75,14 @@ func parseFlags() {
 	factorioConfigFile := flag.String("config", "config/config.ini", "Specify location of Factorio config.ini file")
 	factorioMaxUpload := flag.Int64("max-upload", 1024*1024*20, "Maximum filesize for uploaded files (default 20MB).")
 	factorioBinary := flag.String("bin", "bin/x64/factorio", "Location of Factorio Server binary file")
+	glibcCustom := flag.String("glibc-custom", "false", "By default false, if custom glibc is required set this to true and add glibc-loc and glibc-lib-loc parameters")
+	glibcLocation := flag.String("glibc-loc", "/opt/glibc-2.18/lib/ld-2.18.so", "Location glibc ld.so file if needed (ex. /opt/glibc-2.18/lib/ld-2.18.so)")
+	glibcLibLoc := flag.String("glibc-lib-loc", "/opt/glibc-2.18/lib", "Location of glibc lib folder (ex. /opt/glibc-2.18/lib)")
 
 	flag.Parse()
-
+	config.glibcCustom = *glibcCustom
+	config.glibcLocation = *glibcLocation
+	config.glibcLibLoc = *glibcLibLoc
 	config.ConfFile = *confFile
 	config.FactorioDir = *factorioDir
 	config.ServerIP = *serverIP

--- a/src/main.go
+++ b/src/main.go
@@ -37,7 +37,6 @@ type Config struct {
 	glibcCustom             string
 	glibcLocation           string
 	glibcLibLoc             string
-	autostart               string
 }
 
 var (
@@ -79,10 +78,8 @@ func parseFlags() {
 	glibcCustom := flag.String("glibc-custom", "false", "By default false, if custom glibc is required set this to true and add glibc-loc and glibc-lib-loc parameters")
 	glibcLocation := flag.String("glibc-loc", "/opt/glibc-2.18/lib/ld-2.18.so", "Location glibc ld.so file if needed (ex. /opt/glibc-2.18/lib/ld-2.18.so)")
 	glibcLibLoc := flag.String("glibc-lib-loc", "/opt/glibc-2.18/lib", "Location of glibc lib folder (ex. /opt/glibc-2.18/lib)")
-	autostart := flag.String("autostart", "false", "Autostart factorio server on bootup of FSM, default false [true/false]")
 
 	flag.Parse()
-	config.autostart = *autostart
 	config.glibcCustom = *glibcCustom
 	config.glibcLocation = *glibcLocation
 	config.glibcLibLoc = *glibcLibLoc

--- a/src/main.go
+++ b/src/main.go
@@ -37,6 +37,7 @@ type Config struct {
 	glibcCustom             string
 	glibcLocation           string
 	glibcLibLoc             string
+	autostart               string
 }
 
 var (
@@ -78,8 +79,10 @@ func parseFlags() {
 	glibcCustom := flag.String("glibc-custom", "false", "By default false, if custom glibc is required set this to true and add glibc-loc and glibc-lib-loc parameters")
 	glibcLocation := flag.String("glibc-loc", "/opt/glibc-2.18/lib/ld-2.18.so", "Location glibc ld.so file if needed (ex. /opt/glibc-2.18/lib/ld-2.18.so)")
 	glibcLibLoc := flag.String("glibc-lib-loc", "/opt/glibc-2.18/lib", "Location of glibc lib folder (ex. /opt/glibc-2.18/lib)")
+	autostart := flag.String("autostart", "false", "Autostart factorio server on bootup of FSM, default false [true/false]")
 
 	flag.Parse()
+	config.autostart = *autostart
 	config.glibcCustom = *glibcCustom
 	config.glibcLocation = *glibcLocation
 	config.glibcLibLoc = *glibcLibLoc
@@ -129,7 +132,7 @@ func main() {
 
 	// Initialize HTTP router
 	router := NewRouter()
-
 	log.Printf("Starting server on: %s:%s", config.ServerIP, config.ServerPort)
 	log.Fatal(http.ListenAndServe(config.ServerIP+":"+config.ServerPort, router))
+
 }


### PR DESCRIPTION
Not the most elegant solution, but does the trick for people using RHEL/Centos

I added 3 new parameters and edited the readme file, in short:
-glibc-custom (if you are using custom glibc, true/false, default false)
-glibc-loc (path to the glibc ld.so file)
-glibc-lib-loc (path to the glibc lib folder)