### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       script:
         - make gen_release
         - pwd
-        - ll
+        - ls -al
         - mv factorio-server-manager-linux.zip ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv factorio-server-manager-windows.zip ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,23 @@ jobs:
     - stage: deploy
       go: 1.x
       language: minimal
-#      before_install:
+      before_install:
+        - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
+        - sudo apt-get install -y nodejs
 #        - docker build -f "docker/Dockerfile-build" -t factorio-server-manager docker
       script:
 #        - pwd
 #        - echo ~
 #        - mkdir -p /home/travis/build/mroote/build
 #        - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
-        - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
-        - sudo apt-get install -y nodejs
+        - cd src/
+        - go test -v
+        - cd ..
         - make gen_release
-        - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
-        - mv /home/travis/build/mroote/build/factorio-server-manager-windows.zip /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip
+        - mv factorio-server-manager-linux.zip ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
+        - mv factorio-server-manager-windows.zip ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip
+#        - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
+#        - mv /home/travis/build/mroote/build/factorio-server-manager-windows.zip /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip
       deploy:
         provider: releases
         api_key: "${GITHUB_TOKEN}"
@@ -23,5 +28,5 @@ jobs:
         on:
           tags: true
         file:
-          - /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
-          - /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip
+          - ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
+          - ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 jobs:
   include:
     - stage: deploy
-      go: 1.13.x
-      language: minimal
+      language: go
+      go: 1.x
       before_install:
         - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
         - sudo apt-get install -y nodejs

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ go:
   - 1.13.x
   - 1.x
 
+os:
+  - linux
+  - windows
+
 env:
   - GO111MODULE=on
 
@@ -16,6 +20,7 @@ jobs:
   include:
     - stage: deploy
       go: 1.x
+      os: linux
       before_install:
         - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
         - sudo apt-get install -y nodejs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 jobs:
   include:
     - stage: deploy
-      go: 1.x
+      go: 1.13.x
       language: minimal
       before_install:
         - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
       script:
         - pwd
         - echo ~
-        - mkdir /home/travis/build/mroote/build
+        - mkdir -p /home/travis/build/mroote/build
         - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
         - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv /home/travis/build/mroote/build/factorio-server-manager-windows.zip /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ jobs:
 #        - echo ~
 #        - mkdir -p /home/travis/build/mroote/build
 #        - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
-        - sudo apt-get install nodejs
-        - sudo apt-get install npm
+        - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
+        - sudo apt-get install -y nodejs
         - make gen_release
         - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv /home/travis/build/mroote/build/factorio-server-manager-windows.zip /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
+language: go
+go:
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - 1.x
+#go: 1.x
+
+script:
+  - cd src/
+  - go test -v
+
 jobs:
   include:
-    - stage: test
-      language: go
-      go: 1.x
-      script:
-        - cd src/
-        - go test -v
     - stage: deploy
-      language: go
+#      language: go
       go: 1.x
       before_install:
         - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ jobs:
     - stage: deploy
       go: 1.x
       language: minimal
-      before_install:
-        - docker build -f "docker/Dockerfile-build" -t factorio-server-manager docker
+#      before_install:
+#        - docker build -f "docker/Dockerfile-build" -t factorio-server-manager docker
       script:
-        - pwd
-        - echo ~
-        - mkdir -p /home/travis/build/mroote/build
-        - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
+#        - pwd
+#        - echo ~
+#        - mkdir -p /home/travis/build/mroote/build
+#        - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
+        - make gen_release
         - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv /home/travis/build/mroote/build/factorio-server-manager-windows.zip /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ go:
   - 1.12.x
   - 1.13.x
   - 1.x
-#go: 1.x
+
+env:
+  - GO111MODULE=on
 
 script:
   - cd src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ jobs:
         - sudo apt-get install -y nodejs
       script:
         - make gen_release
-        - pwd
-        - ls -al
         - mv build/factorio-server-manager-linux.zip ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv build/factorio-server-manager-windows.zip ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jobs:
         - docker build -f "docker/Dockerfile-build" -t factorio-server-manager docker
       script:
         - pwd
+        - echo ~
         - mkdir /home/travis/build/mroote/build
         - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
         - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ jobs:
         - make gen_release
         - pwd
         - ls -al
-        - mv factorio-server-manager-linux.zip ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
-        - mv factorio-server-manager-windows.zip ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip
+        - mv build/factorio-server-manager-linux.zip ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
+        - mv build/factorio-server-manager-windows.zip ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip
       deploy:
         provider: releases
         api_key: "${GITHUB_TOKEN}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jobs:
 #        - echo ~
 #        - mkdir -p /home/travis/build/mroote/build
 #        - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
+        - sudo apt-get install nodejs
+        - sudo apt-get install npm
         - make gen_release
         - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv /home/travis/build/mroote/build/factorio-server-manager-windows.zip /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,16 @@ script:
 jobs:
   include:
     - stage: deploy
-#      language: go
       go: 1.x
       before_install:
         - curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
         - sudo apt-get install -y nodejs
-#        - docker build -f "docker/Dockerfile-build" -t factorio-server-manager docker
       script:
-#        - pwd
-#        - echo ~
-#        - mkdir -p /home/travis/build/mroote/build
-#        - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
-#        - cd src/
-#        - go test -v
-#        - cd ..
         - make gen_release
+        - pwd
+        - ll
         - mv factorio-server-manager-linux.zip ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv factorio-server-manager-windows.zip ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip
-#        - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip
-#        - mv /home/travis/build/mroote/build/factorio-server-manager-windows.zip /home/travis/factorio-server-manager-windows-${TRAVIS_TAG}.zip
       deploy:
         provider: releases
         api_key: "${GITHUB_TOKEN}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 jobs:
   include:
+    - stage: test
+      language: go
+      go: 1.x
+      script:
+        - cd src/
+        - go test -v
     - stage: deploy
       language: go
       go: 1.x
@@ -12,9 +18,9 @@ jobs:
 #        - echo ~
 #        - mkdir -p /home/travis/build/mroote/build
 #        - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
-        - cd src/
-        - go test -v
-        - cd ..
+#        - cd src/
+#        - go test -v
+#        - cd ..
         - make gen_release
         - mv factorio-server-manager-linux.zip ~/factorio-server-manager-linux-${TRAVIS_TAG}.zip
         - mv factorio-server-manager-windows.zip ~/factorio-server-manager-windows-${TRAVIS_TAG}.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jobs:
       before_install:
         - docker build -f "docker/Dockerfile-build" -t factorio-server-manager docker
       script:
+        - pwd
         - mkdir /home/travis/build/mroote/build
         - docker run -t -e FAC_BRANCH=$TRAVIS_BRANCH -v /home/travis/build/mroote/build:/build factorio-server-manager
         - mv /home/travis/build/mroote/build/factorio-server-manager-linux.zip /home/travis/factorio-server-manager-linux-${TRAVIS_TAG}.zip

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ endif
 build: $(release)
 
 build/factorio-server-manager-%.zip: clean app/bundle factorio-server-manager-%
+	@echo "Test if the correct is built!!"
 	@mkdir -p build/
 	@echo "Packaging Build - $@"
 	@cp -r app/ factorio-server-manager/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ endif
 build: $(release)
 
 build/factorio-server-manager-%.zip: clean app/bundle factorio-server-manager-%
-	@echo "Test if the correct is built!!"
 	@mkdir -p build/
 	@echo "Packaging Build - $@"
 	@cp -r app/ factorio-server-manager/


### PR DESCRIPTION
Your current travis-script has a few flaws, so i decided to make a better version of it :)

My changes:
- Run the go tests, on windows and linux, on go 1.11, 1.12, 1.13 and the newest 1.x
- Only run the deploy, when the go tests where successful.
- Run the script, on everything calling it (PR, other repos, local, etc). Previously it was only possible to run it on Branches inside this Main-Repo!