### PR TITLE
Fix console

### DIFF
--- a/src/factorio_server.go
+++ b/src/factorio_server.go
@@ -139,7 +139,7 @@ func initFactorio() (f *FactorioServer, err error) {
 	f.BaseModVersion = modInfo.Version
 
 	// load admins from additional file
-	if(f.Version.Greater(Version{0,17,0})) {
+	if (f.Version.Greater(Version{0, 17, 0})) {
 		if _, err := os.Stat(filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile)); os.IsNotExist(err) {
 			//save empty admins-file
 			ioutil.WriteFile(filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile), []byte("[]"), 0664)
@@ -190,7 +190,7 @@ func (f *FactorioServer) Run() error {
 		"--rcon-port", strconv.Itoa(config.FactorioRconPort),
 		"--rcon-password", config.FactorioRconPass)
 
-	if(f.Version.Greater(Version{0,17,0})) {
+	if (f.Version.Greater(Version{0, 17, 0})) {
 		args = append(args, "--server-adminlist", filepath.Join(config.FactorioConfigDir, config.FactorioAdminFile))
 	}
 
@@ -265,11 +265,11 @@ func (f *FactorioServer) parseRunningCommand(std io.ReadCloser) (err error) {
 				}
 			}
 			// If rcon port opens indicated in log connect to rcon
-			rconLog := "Starting RCON interface at port " + strconv.Itoa(config.FactorioRconPort)
+			rconLog := "Starting RCON interface at IP"
 			// check if slice index is greater than 2 to prevent panic
 			if len(line) > 2 {
 				// log line for opened rcon connection
-				if strings.Join(line[3:], " ") == rconLog {
+				if strings.Contains(strings.Join(line, " "), rconLog) {
 					log.Printf("Rcon running on Factorio Server")
 					err = connectRC()
 					if err != nil {

--- a/src/wsclient.go
+++ b/src/wsclient.go
@@ -29,6 +29,7 @@ func (client *Client) Read() {
 			handler(client, message.Data)
 		}
 	}
+	client.socket.Close()
 }
 
 func (client *Client) Write() {
@@ -37,6 +38,7 @@ func (client *Client) Write() {
 			break
 		}
 	}
+	client.socket.Close()
 }
 
 func (client *Client) Close() {

--- a/src/wsclient.go
+++ b/src/wsclient.go
@@ -29,7 +29,6 @@ func (client *Client) Read() {
 			handler(client, message.Data)
 		}
 	}
-	client.socket.Close()
 }
 
 func (client *Client) Write() {
@@ -38,7 +37,6 @@ func (client *Client) Write() {
 			break
 		}
 	}
-	client.socket.Close()
 }
 
 func (client *Client) Close() {

--- a/src/wsroutes.go
+++ b/src/wsroutes.go
@@ -20,7 +20,7 @@ func IsClosed(ch <-chan Message) bool {
 func logSubscribe(client *Client, data interface{}) {
 	go func() {
 		logfile := filepath.Join(config.FactorioDir, "factorio-server-console.log")
-		t, err := tail.TailFile(logfile, tail.Config{Follow: true})
+		t, err := tail.TailFile(logfile, tail.Config{Follow: true, Poll: true})
 		if err != nil {
 			log.Printf("Error subscribing to tail log %s", err)
 			return


### PR DESCRIPTION
I fixed the console #76.

- The Rcon session did not start, because factorio changed a log line. 
- I noticed FSM crashes after the ingame chat was used #165 => `panic: send on closed channel`

If you have trouble to load the UI and it is really slow, just delete the factorio-server-console.log 😉 
